### PR TITLE
fix-no-word-search

### DIFF
--- a/front/components/molecules/SearchUsers.vue
+++ b/front/components/molecules/SearchUsers.vue
@@ -37,7 +37,11 @@ export default {
   },
   watch: {
     userword () {
-      this.delayFunc()
+      if (this.userword) {
+        this.delayFunc()
+      } else {
+        this.users = []
+      }
     }
   },
   created () {


### PR DESCRIPTION
検索ワードを入力してから全文字消した際に検索対象が全てになり全ユーザが検索されてしまうエラーの解消